### PR TITLE
[fix] 로그인 필터 수정

### DIFF
--- a/src/main/java/com/beside/mamgwanboo/common/filter/SignWebFilter.java
+++ b/src/main/java/com/beside/mamgwanboo/common/filter/SignWebFilter.java
@@ -69,6 +69,7 @@ public class SignWebFilter implements WebFilter {
         .setComplete();
   }
 
+  @SuppressWarnings("checkstyle:EmptyCatchBlock")
   private Optional<MamgwanbooJwtPayload> getJwtPayload(ServerHttpRequest serverHttpRequest) {
     MultiValueMap<String, HttpCookie> cookies = serverHttpRequest.getCookies();
 

--- a/src/main/java/com/beside/mamgwanboo/common/filter/StaticWebFilter.java
+++ b/src/main/java/com/beside/mamgwanboo/common/filter/StaticWebFilter.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBufferUtils;
@@ -22,6 +23,7 @@ import reactor.core.publisher.Mono;
 import reactor.util.annotation.NonNull;
 
 @Component
+@Order(-1)
 public class StaticWebFilter implements WebFilter {
   private final List<String> indexWhiteList;
   private final String staticPath;

--- a/src/main/java/com/beside/mamgwanboo/common/service/JwtService.java
+++ b/src/main/java/com/beside/mamgwanboo/common/service/JwtService.java
@@ -59,17 +59,4 @@ public class JwtService {
             ProtocolBufferUtil.parse(jsonString, MamgwanbooJwtPayload.newBuilder())
         );
   }
-
-  public Boolean isSigned(String jwt) {
-    try {
-      Jwts.parserBuilder()
-          .setSigningKey(Keys.hmacShaKeyFor(baseKey.getBytes(StandardCharsets.UTF_8)))
-          .build()
-          .parseClaimsJws(jwt);
-    } catch (RuntimeException runtimeException) {
-      return false;
-    }
-
-    return true;
-  }
 }

--- a/src/main/java/com/beside/mamgwanboo/sign/handler/SignHandler.java
+++ b/src/main/java/com/beside/mamgwanboo/sign/handler/SignHandler.java
@@ -6,6 +6,7 @@ import com.beside.mamgwanboo.common.util.ProtocolBufferUtil;
 import com.beside.mamgwanboo.user.repository.UserRepository;
 import com.beside.mamgwanboo.user.service.UserService;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
@@ -45,7 +46,7 @@ public class SignHandler implements HandlerFunction<ServerResponse> {
                 .flatMap(isExists -> {
                   if (!isExists) {
                     return ServerResponse
-                        .noContent()
+                        .status(HttpStatus.UNAUTHORIZED)
                         .build();
                   }
 
@@ -68,6 +69,9 @@ public class SignHandler implements HandlerFunction<ServerResponse> {
                               .build()
                       );
                 })
-        );
+        )
+        .onErrorResume(throwable -> ServerResponse
+            .status(HttpStatus.UNAUTHORIZED)
+            .build());
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,8 +24,8 @@ jwt:
     name: jwt
 sign:
   whitePaths: /sign, /users
-  cookie:
-    name: jwt
+  attributeName: jwt
+  cookieName: jwt
 
 ---
 

--- a/src/test/java/com/beside/mamgwanboo/common/service/JwtServiceTest.java
+++ b/src/test/java/com/beside/mamgwanboo/common/service/JwtServiceTest.java
@@ -1,9 +1,7 @@
 package com.beside.mamgwanboo.common.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.MalformedJwtException;
@@ -90,46 +88,5 @@ class JwtServiceTest {
     assertThat(mamgwanbooJwtPayload).isEqualTo(MamgwanbooJwtPayload.newBuilder()
         .setSequence("sequence")
         .build());
-  }
-
-  @Test
-  void isSignedWhenSigned() {
-    // given
-    String mamwanbooJwt =
-        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.ewogICJzZXF1ZW5jZSI6ICJzZXF1ZW5jZSIKfQ.x0gx0U6N6XxAqdd2wyUT2h8MzyRAwhJGhFahHXisOwg";
-
-    // when
-    boolean result = jwtService.isSigned(mamwanbooJwt);
-
-    // then
-    assertTrue(result);
-  }
-
-  @Test
-  void isSignedWhenUnsigned() {
-    // given
-    String mamwanbooJwt =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXF1ZW5jZSI6ImFzZGYifQ.7xaBbcddICubDbnYRDhVbWWiyQ3XhwzB2-ry6xFJdws";
-
-    // when
-    boolean result = jwtService.isSigned(mamwanbooJwt);
-
-    // then
-    assertFalse(result);
-  }
-
-  @ParameterizedTest
-  @ValueSource(
-      strings = {
-          "asdf",
-          ""
-      }
-  )
-  void isSignedWhenInvalidJwt(String jwt) {
-    // when
-    boolean result = jwtService.isSigned(jwt);
-
-    // then
-    assertFalse(result);
   }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
<!-- ex) - 카카오 소셜 로그인 추가. -->
- 상태코드를 401(unauthorized)로 변경.
- 잘못된 코드 수정. - Mono.empty()
- 로그인 후의 요청에는 jwtPayload를 attribute로 넣어줌.

### 테스트 결과
<!-- ex) - 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. <br>
결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
