### PR TITLE
[fix] sign 로직 수정

### DIFF
--- a/src/main/java/com/beside/mamgwanboo/common/filter/SignWebFilter.java
+++ b/src/main/java/com/beside/mamgwanboo/common/filter/SignWebFilter.java
@@ -4,12 +4,11 @@ import com.beside.mamgwanboo.common.service.JwtService;
 import com.google.common.base.Charsets;
 import com.mongodb.lang.NonNull;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -50,18 +49,18 @@ public class SignWebFilter implements WebFilter {
       return chain.filter(exchange);
     }
 
-    MultiValueMap<String, HttpCookie> cookies = exchange.getRequest().getCookies();
+    List<String> authorizations = exchange.getRequest().getHeaders().get("Authorization");
 
-    if (cookies.isEmpty() || !cookies.containsKey(cookieName)) {
+    if (Objects.isNull(authorizations) || authorizations.isEmpty()) {
       ServerHttpResponse serverHttpResponse = exchange.getResponse();
       serverHttpResponse.setStatusCode(HttpStatus.UNAUTHORIZED);
       return serverHttpResponse.setComplete();
     }
 
-    List<HttpCookie> jwtCookies = cookies.get(cookieName);
-    for (HttpCookie jwtCookie : jwtCookies) {
+
+    for (String authorization : authorizations) {
       try {
-        return jwtService.getPayload(jwtCookie.getValue())
+        return jwtService.getPayload(authorization)
             .flatMap(mamgwanbooJwtPayload -> {
               exchange.getAttributes().put(
                   attributeName,

--- a/src/main/java/com/beside/mamgwanboo/common/filter/SignWebFilter.java
+++ b/src/main/java/com/beside/mamgwanboo/common/filter/SignWebFilter.java
@@ -19,18 +19,15 @@ import reactor.core.publisher.Mono;
 public class SignWebFilter implements WebFilter {
   private static final String API_PATH_PREFIX = "/api";
   private final List<String> whitePaths;
-  private final String cookieName;
   private final String attributeName;
   private final JwtService jwtService;
 
   public SignWebFilter(
       @Value("${sign.whitePaths}") List<String> whitePaths,
-      @Value("${sign.cookieName}") String cookieName,
       @Value("${sign.attributeName}") String attributeName,
       JwtService jwtService
   ) {
     this.whitePaths = whitePaths;
-    this.cookieName = cookieName;
     this.attributeName = attributeName;
     this.jwtService = jwtService;
   }

--- a/src/main/java/com/beside/mamgwanboo/sign/handler/SignHandler.java
+++ b/src/main/java/com/beside/mamgwanboo/sign/handler/SignHandler.java
@@ -7,7 +7,6 @@ import com.beside.mamgwanboo.user.repository.UserRepository;
 import com.beside.mamgwanboo.user.service.UserService;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.HandlerFunction;
@@ -58,15 +57,7 @@ public class SignHandler implements HandlerFunction<ServerResponse> {
                       .flatMap(jwt ->
                           ServerResponse
                               .ok()
-                              .cookie(
-                                  ResponseCookie
-                                      .from(
-                                          "jwt",
-                                          jwt
-                                      )
-                                      .build()
-                              )
-                              .build()
+                              .bodyValue(jwt)
                       );
                 })
         )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,6 @@ jwt:
 sign:
   whitePaths: /sign, /users
   attributeName: jwt
-  cookieName: jwt
 
 ---
 


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
<!-- ex) - 카카오 소셜 로그인 추가. -->
- cookie -> authorization 헤더로 수정.
- sign api의 응답을 body에 담아주도록 수정.


### 테스트 결과
<!-- ex) - 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. <br>
결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
