### PR TITLE
[feature] 친구 정보 조회시, levelInfo(주고받은 숫자, 관계 레벨) 추가

### DIFF
--- a/src/main/java/com/beside/startrail/friend/service/FriendService.java
+++ b/src/main/java/com/beside/startrail/friend/service/FriendService.java
@@ -2,12 +2,20 @@ package com.beside.startrail.friend.service;
 
 import com.beside.startrail.common.protocolbuffer.friend.FriendProtoUtil;
 import com.beside.startrail.common.type.YnType;
+
 import java.util.List;
 
 import com.beside.startrail.friend.document.Friend;
 import com.beside.startrail.friend.repository.FriendRepository;
+import com.beside.startrail.relationLevel.document.RelationLevel;
+import com.beside.startrail.relationLevel.repository.RelationLevelRepository;
+import com.beside.startrail.relationship.model.RelationshipCountResult;
+import com.beside.startrail.relationship.repository.CustomRelationshipRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+import protobuf.common.LevelInformationProto;
+import protobuf.common.RelationLevelGetCriteriaProto;
 import protobuf.friend.FriendGetCriteriaProto;
 import protobuf.friend.FriendPostProto;
 import protobuf.friend.FriendPutProto;
@@ -20,14 +28,24 @@ import reactor.core.publisher.Mono;
 public class FriendService {
 
     private final FriendRepository friendRepository;
+    private final RelationLevelRepository relationLevelRepository;
+    private final CustomRelationshipRepository customRelationshipRepository;
 
-    public FriendService(FriendRepository friendRepository) {
+    public FriendService(FriendRepository friendRepository,
+                         RelationLevelRepository relationLevelRepository,
+                         CustomRelationshipRepository customRelationshipRepository) {
         this.friendRepository = friendRepository;
+        this.relationLevelRepository = relationLevelRepository;
+        this.customRelationshipRepository = customRelationshipRepository;
     }
 
     public Mono<FriendResponseProto> getFriendBySequence(String userSequence, String sequence){
         return getVerifiedFriend(userSequence, sequence)
-                .flatMap(friend -> Mono.just(FriendProtoUtil.toFriendResponseProto(friend)));
+                .flatMap(friend -> getFriendLevelInfo(userSequence, friend.getSequence())
+                        .map(levelInformation ->
+                                setLevelInfo(FriendProtoUtil.toFriendResponseProto(friend), levelInformation)
+                        )
+                );
     }
 
     public Mono<List<FriendResponseProto>> createFriend(String userSequence, FriendPostProto friendCreateDto){
@@ -40,20 +58,30 @@ public class FriendService {
         return getVerifiedFriend(userSequence, sequence)
                 .flatMap(friend -> Mono.just(FriendProtoUtil.updateDtoToDocument(friend, friendPutProto)))
                 .flatMap(updateFrd -> friendRepository.save(updateFrd))
-                .flatMap(friend -> Mono.just(FriendProtoUtil.toFriendResponseProto(friend)));
+                .flatMap(friend -> getFriendLevelInfo(userSequence, friend.getSequence())
+                        .map(levelInformation ->
+                                setLevelInfo(FriendProtoUtil.toFriendResponseProto(friend), levelInformation)
+                        )
+                );
     }
 
     public Mono<FriendResponseProto> removeFriend(String userSequence, String sequence) {
         return getVerifiedFriend(userSequence, sequence)
                 .flatMap(friend -> Mono.just(friend.notUseYn(friend)))
                 .flatMap(friend -> friendRepository.save(friend))
-                .flatMap(friend -> Mono.just(FriendProtoUtil.toFriendResponseProto(friend)));
+                .map(friend -> FriendProtoUtil.toFriendResponseProto(friend));
 
     }
 
     public Flux<FriendResponseProto> getFriendsByCriteria(String userSequence, FriendGetCriteriaProto friendSearchCriteria){
         return friendRepository.findFriendsByCriteria(userSequence, friendSearchCriteria)
-                .flatMap(friend -> Mono.just(FriendProtoUtil.toFriendResponseProto(friend)));
+                .flatMap(friend ->
+                        getFriendLevelInfo(userSequence, friend.getSequence())
+                                .map(levelInformation ->
+                                        setLevelInfo(FriendProtoUtil.toFriendResponseProto(friend), levelInformation)
+                                )
+
+                );
     }
 
     private Mono<Friend> getVerifiedFriend(String userSequence, String sequence){
@@ -63,5 +91,42 @@ public class FriendService {
                                 new IllegalArgumentException("Not Found Friend")
                         )
                 );
+    }
+
+    private Mono<LevelInformationProto> getFriendLevelInfo(String userSequence, String friendSequence){
+        return customRelationshipRepository.countByFriend(userSequence, friendSequence, YnType.Y)
+                .switchIfEmpty(Mono.just(RelationshipCountResult.builder().build()))
+                .flatMap(relationshipCountResult ->
+                        getRelationLevelByCount(relationshipCountResult.getTotal())
+                                .map(relationLevel -> toLevelInformationProto(relationshipCountResult, relationLevel))
+                );
+    }
+
+    private Mono<RelationLevel> getRelationLevelByCount(Integer count){
+        return relationLevelRepository.findRelationLevelByCriteria(toRelationLevelCountCriteria(count))
+                .collectList()
+                .map(relationLevels -> relationLevels.stream().findFirst().orElse(null));
+    }
+
+    private RelationLevelGetCriteriaProto toRelationLevelCountCriteria(Integer val) {
+        return RelationLevelGetCriteriaProto.newBuilder()
+                .setSearchKey("count")
+                .setSearchValue(String.valueOf(val))
+                .build();
+    }
+
+    private LevelInformationProto toLevelInformationProto(RelationshipCountResult relationshipCountResult, RelationLevel relationLevel){
+        return LevelInformationProto.newBuilder()
+                .setTotal(relationshipCountResult.getTotal())
+                .setGiven(relationshipCountResult.getGiven())
+                .setTaken(relationshipCountResult.getTaken())
+                .setLevel(ObjectUtils.isEmpty(relationLevel) ? 1 : relationLevel.getLevel())
+                .build();
+    }
+
+    private FriendResponseProto setLevelInfo(FriendResponseProto friendResponseProto, LevelInformationProto levelInformationProto){
+        return friendResponseProto.toBuilder()
+                .setLevelInformation(levelInformationProto)
+                .build();
     }
 }

--- a/src/main/java/com/beside/startrail/relationship/repository/CustomRelationshipRepository.java
+++ b/src/main/java/com/beside/startrail/relationship/repository/CustomRelationshipRepository.java
@@ -6,4 +6,6 @@ import reactor.core.publisher.Mono;
 
 public interface CustomRelationshipRepository {
   Mono<RelationshipCountResult> count(String sequence, YnType useYn);
+
+  Mono<RelationshipCountResult> countByFriend(String sequence, String friendSequence, YnType useYn);
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
<!-- ex) - 카카오 소셜 로그인 추가. -->
친구 정보 조회시, levelInfo(주고받은 숫자, 관계레벨) 데이터 추가
### 테스트 결과
<!-- ex) - 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. <br>
결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
